### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.1 - 2023-03-08
+
+## Fixed
+- Removed `symbol` as mandatory parameter in `currentAllOpenOrders()` within `UMAccount.java` and `CMAccount.java` classes
+
+## Updated
+- Bumped `org.json` package version to `20230227`
+
 ## 3.0.0 - 2023-03-06
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.binance</groupId>
     <artifactId>binance-futures-connector-java</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>lightweight connector to Futures API</description>
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20210307</version>
+            <version>20230227</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/binance/connector/futures/client/impl/cm_futures/CMAccount.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/cm_futures/CMAccount.java
@@ -90,14 +90,13 @@ public class CMAccount extends Account {
      *    https://binance-docs.github.io/apidocs/delivery/en/#current-all-open-orders-user_data</a>
      */
     public String currentAllOpenOrders(LinkedHashMap<String, Object> parameters) {
-        ParameterChecker.checkOrParameters(parameters, "symbol", "pair");
         return super.currentAllOpenOrders(parameters);
     }
 
     /**
      * Get all open orders on a symbol. Careful when accessing this with no symbol.
      * <br><br>
-     * GET /v1/openOrders
+     * GET /v1/allOrders
      * <br>
      * @param
      * parameters LinkedHashedMap of String,Object pair

--- a/src/main/java/com/binance/connector/futures/client/impl/um_futures/UMAccount.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/um_futures/UMAccount.java
@@ -68,21 +68,20 @@ public class UMAccount extends Account {
      * parameters LinkedHashedMap of String,Object pair
      *            where String is the name of the parameter and Object is the value of the parameter
      * <br><br>
-     * symbol -- mandatory/string <br>
+     * symbol -- optional/string <br>
      * recvWindow -- optional/long <br>
      * @return String
      * @see <a href="https://binance-docs.github.io/apidocs/futures/en/#current-all-open-orders-user_data">
      *    https://binance-docs.github.io/apidocs/futures/en/#current-all-open-orders-user_data</a>
      */
     public String currentAllOpenOrders(LinkedHashMap<String, Object> parameters) {
-        ParameterChecker.checkParameter(parameters, "symbol", String.class);
         return super.currentAllOpenOrders(parameters);
     }
 
     /**
      * Get all open orders on a symbol. Careful when accessing this with no symbol.
      * <br><br>
-     * GET /v1/openOrders
+     * GET /v1/allOrders
      * <br>
      * @param
      * parameters LinkedHashedMap of String,Object pair

--- a/src/test/java/unit/cm_futures/account/TestCMCurrentAllOpenOrders.java
+++ b/src/test/java/unit/cm_futures/account/TestCMCurrentAllOpenOrders.java
@@ -2,7 +2,6 @@ package unit.cm_futures.account;
 
 import com.binance.connector.futures.client.enums.HttpMethod;
 import com.binance.connector.futures.client.impl.CMFuturesClientImpl;
-import com.binance.connector.futures.client.exceptions.BinanceConnectorException;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
@@ -11,7 +10,6 @@ import unit.MockData;
 import unit.MockWebServerDispatcher;
 import java.util.LinkedHashMap;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 public class TestCMCurrentAllOpenOrders {
     private MockWebServer mockWebServer;
@@ -33,7 +31,8 @@ public class TestCMCurrentAllOpenOrders {
         mockWebServer.setDispatcher(dispatcher);
 
         CMFuturesClientImpl client = new CMFuturesClientImpl(MockData.API_KEY, MockData.SECRET_KEY, baseUrl);
-        assertThrows(BinanceConnectorException.class, () -> client.account().currentAllOpenOrders(parameters));
+        String result = client.account().currentAllOpenOrders(parameters);
+        assertEquals(MockData.MOCK_RESPONSE, result);
     }
 
     @Test

--- a/src/test/java/unit/um_futures/account/TestUMCurrentAllOpenOrders.java
+++ b/src/test/java/unit/um_futures/account/TestUMCurrentAllOpenOrders.java
@@ -1,7 +1,6 @@
 package unit.um_futures.account;
 
 import com.binance.connector.futures.client.enums.HttpMethod;
-import com.binance.connector.futures.client.exceptions.BinanceConnectorException;
 import com.binance.connector.futures.client.impl.UMFuturesClientImpl;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockWebServer;
@@ -11,7 +10,6 @@ import unit.MockData;
 import unit.MockWebServerDispatcher;
 import java.util.LinkedHashMap;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 public class TestUMCurrentAllOpenOrders {
     private MockWebServer mockWebServer;
@@ -33,7 +31,8 @@ public class TestUMCurrentAllOpenOrders {
         mockWebServer.setDispatcher(dispatcher);
 
         UMFuturesClientImpl client = new UMFuturesClientImpl(MockData.API_KEY, MockData.SECRET_KEY, baseUrl);
-        assertThrows(BinanceConnectorException.class, () -> client.account().currentAllOpenOrders(parameters));
+        String result = client.account().currentAllOpenOrders(parameters);
+        assertEquals(MockData.MOCK_RESPONSE, result);
     }
 
     @Test


### PR DESCRIPTION
## 3.0.1 - 2023-03-08

## Fixed
- Removed `symbol` as mandatory parameter in `currentAllOpenOrders()` within `UMAccount.java` and `CMAccount.java` classes

## Updated
- Bumped `org.json` package version to `20230227`