### PR TITLE
Feature proposal: client side websocket ping

### DIFF
--- a/src/main/java/com/binance/connector/futures/client/impl/CMWebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/CMWebsocketClientImpl.java
@@ -5,6 +5,7 @@ import com.binance.connector.futures.client.utils.RequestBuilder;
 import com.binance.connector.futures.client.utils.WebSocketCallback;
 import com.binance.connector.futures.client.utils.ParameterChecker;
 import okhttp3.Request;
+import java.time.Duration;
 
 /**
  * <h2>COIN-M Websocket Streams</h2>
@@ -17,11 +18,15 @@ import okhttp3.Request;
  */
 public class CMWebsocketClientImpl extends WebsocketClientImpl {
     public CMWebsocketClientImpl() {
-        super(DefaultUrls.COINM_WS_URL);
+        super(DefaultUrls.COINM_WS_URL, Duration.ZERO);
     }
 
     public CMWebsocketClientImpl(String baseUrl) {
-        super(baseUrl);
+        super(baseUrl, Duration.ZERO);
+    }
+
+    public CMWebsocketClientImpl(String baseUrl, Duration pingInterval) {
+        super(baseUrl, pingInterval);
     }
 
     /**

--- a/src/main/java/com/binance/connector/futures/client/impl/UMWebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/UMWebsocketClientImpl.java
@@ -5,6 +5,7 @@ import com.binance.connector.futures.client.utils.RequestBuilder;
 import com.binance.connector.futures.client.utils.WebSocketCallback;
 import com.binance.connector.futures.client.utils.ParameterChecker;
 import okhttp3.Request;
+import java.time.Duration;
 
 /**
  * <h2>USDⓈ-M  Websocket Streams</h2>
@@ -18,11 +19,15 @@ import okhttp3.Request;
 public class UMWebsocketClientImpl extends WebsocketClientImpl {
 
     public UMWebsocketClientImpl() {
-        super(DefaultUrls.USDM_WS_URL);
+        super(DefaultUrls.USDM_WS_URL, Duration.ZERO);
     }
 
     public UMWebsocketClientImpl(String baseUrl) {
-        super(baseUrl);
+        super(baseUrl, Duration.ZERO);
+    }
+
+    public UMWebsocketClientImpl(String baseUrl, Duration pingInterval) {
+        super(baseUrl, pingInterval);
     }
 
     /**

--- a/src/main/java/com/binance/connector/futures/client/impl/WebsocketClientImpl.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/WebsocketClientImpl.java
@@ -7,6 +7,7 @@ import com.binance.connector.futures.client.utils.UrlBuilder;
 import com.binance.connector.futures.client.utils.WebSocketCallback;
 import com.binance.connector.futures.client.utils.WebSocketConnection;
 import com.binance.connector.futures.client.utils.ParameterChecker;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,13 +29,15 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class WebsocketClientImpl implements WebsocketClient {
     private final String baseUrl;
+    private final Duration pingInterval;
     private final Map<Integer, WebSocketConnection> connections = new HashMap<>();
     private final WebSocketCallback noopCallback = msg -> {
     };
     private static final Logger logger = LoggerFactory.getLogger(WebsocketClientImpl.class);
 
-    public WebsocketClientImpl(String baseUrl) {
+    public WebsocketClientImpl(String baseUrl, Duration pingInterval) {
         this.baseUrl = baseUrl;
+        this.pingInterval = pingInterval;
     }
 
     public WebSocketCallback getNoopCallback() {
@@ -715,7 +718,7 @@ public abstract class WebsocketClientImpl implements WebsocketClient {
             WebSocketCallback onFailureCallback,
             Request request
     ) {
-        WebSocketConnection connection = new WebSocketConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request);
+        WebSocketConnection connection = new WebSocketConnection(onOpenCallback, onMessageCallback, onClosingCallback, onFailureCallback, request, this.pingInterval);
         connection.connect();
         int connectionId = connection.getConnectionId();
         connections.put(connectionId, connection);

--- a/src/main/java/com/binance/connector/futures/client/utils/WebSocketConnection.java
+++ b/src/main/java/com/binance/connector/futures/client/utils/WebSocketConnection.java
@@ -1,5 +1,6 @@
 package com.binance.connector.futures.client.utils;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -12,7 +13,6 @@ import org.slf4j.LoggerFactory;
 public class WebSocketConnection extends WebSocketListener {
     private static final AtomicInteger connectionCounter = new AtomicInteger(0);
     private static final int NORMAL_CLOSURE_STATUS = 1000;
-    private static final OkHttpClient client = HttpClientSingleton.getHttpClient();
     private static final Logger logger = LoggerFactory.getLogger(WebSocketConnection.class);
 
     private final WebSocketCallback onOpenCallback;
@@ -23,6 +23,7 @@ public class WebSocketConnection extends WebSocketListener {
     private final Request request;
     private final String streamName;
 
+    private final OkHttpClient client;
     private WebSocket webSocket;
 
     private final Object mutex;
@@ -32,7 +33,8 @@ public class WebSocketConnection extends WebSocketListener {
             WebSocketCallback onMessageCallback,
             WebSocketCallback onClosingCallback,
             WebSocketCallback onFailureCallback,
-            Request request
+            Request request,
+            Duration pingInterval
     ) {
         this.onOpenCallback = onOpenCallback;
         this.onMessageCallback = onMessageCallback;
@@ -43,6 +45,10 @@ public class WebSocketConnection extends WebSocketListener {
         this.streamName = request.url().host() + request.url().encodedPath();
         this.webSocket = null;
         this.mutex = new Object();
+
+        OkHttpClient.Builder builder = HttpClientSingleton.getHttpClient().newBuilder();
+        builder.pingInterval(pingInterval);
+        this.client = builder.build();
     }
 
     public void connect() {


### PR DESCRIPTION
Hello, this PR is my feature proposition.

Currently this library is not able to detect lost connection with Binance Websocket API.

I have exposed pingInterval attribute of **OkHttpClient** as optional parameter for **UM/CMWebsocketClientImpl** to be set by user accordingly to needs. This issues the client to send ping frames to Binance Websocket API and await pong response. When connection is lost (e.g. due to Wi-Fi/Internet disconnection), *onFailureCallback* will be triggered after at most *pingInterval*.

Please let me know if this change fits. I'm open to comments and suggestions.