### PR TITLE
v3.0.4

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -13,9 +13,9 @@ jobs:
         java-version: [ 8, 11, 17 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with: # running setup-java again overwrites the settings.xml
           distribution: 'adopt' # See 'Supported distributions' for available options
           java-version: '8'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.4 - 2024-01-09
+## 3.0.4 - 2024-01-10
 
 ### Fixed
 - `DecimalFormat` with `Locale.ENGLISH` for requests with `Double` to have `.` as decimal separator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.4 - 2024-01-09
+
+### Fixed
+- `DecimalFormat` with `Locale.ENGLISH` for requests with `Double` to have `.` as decimal separator.
+
+### Updated
+- Bumped `logback-classic` dependency to `1.2.13`.
+
 ## 3.0.3 - 2023-10-18
 
 ### Updated

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.2.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/binance/connector/futures/client/utils/UrlBuilder.java
+++ b/src/main/java/com/binance/connector/futures/client/utils/UrlBuilder.java
@@ -4,8 +4,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 
@@ -115,7 +117,9 @@ public final class UrlBuilder {
 
     private static DecimalFormat getFormatter() {
         if (null == df) {
-            df = new DecimalFormat();
+            // Overrides the default Locale
+            DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.ENGLISH);
+            df = new DecimalFormat("#,##0.###", symbols);
             df.setMaximumFractionDigits(MAX_DECIMAL_DIGITS);
             df.setGroupingUsed(false);
         }

--- a/src/test/java/examples/cm_futures/account/QueryOrder.java
+++ b/src/test/java/examples/cm_futures/account/QueryOrder.java
@@ -12,13 +12,16 @@ public final class QueryOrder {
     private QueryOrder() {
     }
 
+    private static final Integer orderId = 123;
     private static final Logger logger = LoggerFactory.getLogger(QueryOrder.class);
+    
     public static void main(String[] args) {
         LinkedHashMap<String, Object> parameters = new LinkedHashMap<>();
 
         CMFuturesClientImpl client = new CMFuturesClientImpl(PrivateConfig.TESTNET_API_KEY, PrivateConfig.TESTNET_SECRET_KEY, PrivateConfig.TESTNET_BASE_URL);
 
         parameters.put("symbol", "BNBUSD_PERP");
+        parameters.put("orderId", orderId);
 
         try {
             String result = client.account().queryOrder(parameters);

--- a/src/test/java/examples/um_futures/account/QueryOrder.java
+++ b/src/test/java/examples/um_futures/account/QueryOrder.java
@@ -11,14 +11,17 @@ import org.slf4j.LoggerFactory;
 public final class QueryOrder {
     private QueryOrder() {
     }
-
+    
+    private static final Integer orderId = 123;
     private static final Logger logger = LoggerFactory.getLogger(QueryOrder.class);
+
     public static void main(String[] args) {
         LinkedHashMap<String, Object> parameters = new LinkedHashMap<>();
 
         UMFuturesClientImpl client = new UMFuturesClientImpl(PrivateConfig.TESTNET_API_KEY, PrivateConfig.TESTNET_SECRET_KEY, PrivateConfig.TESTNET_BASE_URL);
 
         parameters.put("symbol", "BNBUSDT");
+        parameters.put("orderId", orderId);
 
         try {
             String result = client.account().queryOrder(parameters);

--- a/src/test/java/unit/TestUrlBuilder.java
+++ b/src/test/java/unit/TestUrlBuilder.java
@@ -3,21 +3,28 @@ package unit;
 import com.binance.connector.futures.client.utils.UrlBuilder;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public class TestUrlBuilder {
     private final String baseUrl = "www.test.com";
     private final String urlPath = "/url/path";
-    private final double key3 = 0.0006;
-    private final double key4 = 0.000000000000000000001;
-    private final int value2 = 2;
+    private final double doubleValue = 0.0006;
+    private final double extensiveDecimalsDouble = 1.123456789101112;  
+    private final double highDouble = 10000.1;
+    private final int intValue = 2;
     private final LinkedHashMap<String, Object> mockParameters = new LinkedHashMap<String, Object>() {{
         put("key1", "value1");
-        put("key2", value2);
-        put("key3", key3);
+        put("key2", intValue);
+        put("key3", doubleValue);
     }};
-    private final ArrayList<String> mockStreams = new ArrayList<String>() {{
+private final LinkedHashMap<String, Object> mockDoubleParameters = new LinkedHashMap<String, Object>() {{
+        put("key1", extensiveDecimalsDouble);
+        put("key2", highDouble);
+
+    }};
+private final ArrayList<String> mockStreams = new ArrayList<String>() {{
         add("stream1");
         add("stream2");
         add("stream3");
@@ -43,14 +50,29 @@ public class TestUrlBuilder {
 
     @Test
     public void testJoinLargeQueryParameters() {
-        mockParameters.put("key4", key4);
-        String joinedQuery = "key1=value1&key2=2&key3=0.0006&key4=0.000000000000000000001";
+        mockParameters.put("key4", extensiveDecimalsDouble);
+        mockParameters.put("key5", highDouble);
+        String joinedQuery = "key1=value1&key2=2&key3=0.0006&key4=1.123456789101112&key5=10000.1";
         assertEquals(joinedQuery, UrlBuilder.joinQueryParameters(mockParameters));
     }
 
     @Test
     public void testJoinQueryParametersWithoutParams() {
         assertEquals("", UrlBuilder.joinQueryParameters(null));
+    }
+
+    /**
+     * Tests the JoinQueryParameters with Locale.IT to ensure that the originated Double maintains the '.' decimal separator instead of being changed to a ','. 
+     * Additionally, the test verifies that there is no dropping of zeros, addition of group separators (','), and limitation on the number of decimal places.
+     */
+    @Test
+    public void testJoinQueryParametersWithLocaleIT() {
+
+        Locale.setDefault(new Locale("it", "IT"));
+
+        String joinedQuery = String.format("key1=%s&key2=%s", extensiveDecimalsDouble, highDouble);
+        String buildQuery = UrlBuilder.joinQueryParameters(mockDoubleParameters);
+        assertEquals(joinedQuery, buildQuery);
     }
 
     @Test


### PR DESCRIPTION
### Fixed
- `DecimalFormat` with `Locale.ENGLISH` for requests with `Double` to have `.` as decimal separator.

### Updated
- Bumped `logback-classic` dependency to `1.2.13`.