### PR TITLE
[Feature] - Account Information V3

### DIFF
--- a/src/main/java/com/binance/connector/futures/client/impl/um_futures/UMAccount.java
+++ b/src/main/java/com/binance/connector/futures/client/impl/um_futures/UMAccount.java
@@ -140,6 +140,25 @@ public class UMAccount extends Account {
         return getRequestHandler().sendSignedRequest(getProductUrl(), ACCOUNT_INFORMATION, parameters, HttpMethod.GET, getShowLimitUsage());
     }
 
+    private final String ACCOUNT_INFORMATION_V3 = "/v3/account";
+    /**
+     * Get current account information. User in single-asset/ multi-assets mode will see different value, see comments in response section for detail.
+     * <br><br>
+     * GET /v3/account
+     * <br>
+     * @param
+     * parameters LinkedHashedMap of String,Object pair
+     *            where String is the name of the parameter and Object is the value of the parameter
+     * <br><br>
+     * recvWindow -- optional/long <br>
+     * @return String
+     * @see <a href="https://developers.binance.com/docs/derivatives/usds-margined-futures/account/rest-api/Account-Information-V3">
+     *    https://developers.binance.com/docs/derivatives/usds-margined-futures/account/rest-api/Account-Information-V3</a>
+     */
+    public String accountInformationV3(LinkedHashMap<String, Object> parameters) {
+        return getRequestHandler().sendSignedRequest(getProductUrl(), ACCOUNT_INFORMATION_V3, parameters, HttpMethod.GET, getShowLimitUsage());
+    }
+
     private final String POSITION_RISK = "/v2/positionRisk";
     /**
      * Get current position information.

--- a/src/test/java/examples/um_futures/account/AccountInformationV3.java
+++ b/src/test/java/examples/um_futures/account/AccountInformationV3.java
@@ -1,0 +1,32 @@
+package examples.um_futures.account;
+
+import com.binance.connector.futures.client.exceptions.BinanceClientException;
+import com.binance.connector.futures.client.exceptions.BinanceConnectorException;
+import com.binance.connector.futures.client.impl.UMFuturesClientImpl;
+import examples.PrivateConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+
+public final class AccountInformationV3 {
+    private AccountInformationV3() {
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(AccountInformationV3.class);
+    public static void main(String[] args) {
+        LinkedHashMap<String, Object> parameters = new LinkedHashMap<>();
+
+        UMFuturesClientImpl client = new UMFuturesClientImpl(PrivateConfig.TESTNET_API_KEY, PrivateConfig.TESTNET_SECRET_KEY, PrivateConfig.TESTNET_BASE_URL);
+
+        try {
+            String result = client.account().accountInformationV3(parameters);
+            logger.info(result);
+        } catch (BinanceConnectorException e) {
+            logger.error("fullErrMessage: {}", e.getMessage(), e);
+        } catch (BinanceClientException e) {
+            logger.error("fullErrMessage: {} \nerrMessage: {} \nerrCode: {} \nHTTPStatusCode: {}",
+                    e.getMessage(), e.getErrMsg(), e.getErrorCode(), e.getHttpStatusCode(), e);
+        }
+    }
+}

--- a/src/test/java/examples/um_futures/account/AccountInformationV3.java
+++ b/src/test/java/examples/um_futures/account/AccountInformationV3.java
@@ -6,7 +6,6 @@ import com.binance.connector.futures.client.impl.UMFuturesClientImpl;
 import examples.PrivateConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.LinkedHashMap;
 
 public final class AccountInformationV3 {

--- a/src/test/java/unit/um_futures/account/TestUMAccountInformationV3.java
+++ b/src/test/java/unit/um_futures/account/TestUMAccountInformationV3.java
@@ -8,9 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import unit.MockData;
 import unit.MockWebServerDispatcher;
-
 import java.util.LinkedHashMap;
-
 import static org.junit.Assert.assertEquals;
 
 public class TestUMAccountInformationV3 {

--- a/src/test/java/unit/um_futures/account/TestUMAccountInformationV3.java
+++ b/src/test/java/unit/um_futures/account/TestUMAccountInformationV3.java
@@ -1,0 +1,37 @@
+package unit.um_futures.account;
+
+import com.binance.connector.futures.client.enums.HttpMethod;
+import com.binance.connector.futures.client.impl.UMFuturesClientImpl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Test;
+import unit.MockData;
+import unit.MockWebServerDispatcher;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestUMAccountInformationV3 {
+    private MockWebServer mockWebServer;
+    private String baseUrl;
+
+    @Before
+    public void init() {
+        this.mockWebServer = new MockWebServer();
+        this.baseUrl = mockWebServer.url(MockData.PREFIX).toString();
+    }
+
+    @Test
+    public void testAccountInformation() {
+        String path = "fapi/v3/account";
+        LinkedHashMap<String, Object> parameters = new LinkedHashMap<>();
+        Dispatcher dispatcher = MockWebServerDispatcher.getDispatcher(MockData.PREFIX, path, MockData.MOCK_RESPONSE, HttpMethod.GET, MockData.HTTP_STATUS_OK);
+        mockWebServer.setDispatcher(dispatcher);
+
+        UMFuturesClientImpl client = new UMFuturesClientImpl(MockData.API_KEY, MockData.SECRET_KEY, baseUrl);
+        String result = client.account().accountInformationV3(parameters);
+        assertEquals(MockData.MOCK_RESPONSE, result);
+    }
+}


### PR DESCRIPTION
# Feature - Account Information V3
Adding the REST API GET for the endpoint `/fapi/v3/account`

## Description
This Pull Request adds the Account Information V3(USER_DATA) REST API Request. 
It also provides some code example and Unit tests

## Motivation
I'm adding the Account Information V3 request since the code only have the V2 implementation. 

## Changes Made
- Added a new method called `accountInformationV3` on `UMAccount` to send the request
- Provided Unit tests for the new method
- Provided code examples of how to use this new method

## Testing
### Verification 1
1. Execute `TestUMAccountInformationV3` unit tests
    - [ ] All tests must pass

### Verification 2
1. Execute `mvn test` on the project root folder
    - [ ] All tests and validations must pass

### Verification 3
1. Open the `PrivateConfig` class and set values for `TESTNET_API_KEY` and `TESTNET_SECRET_KEY`
2. Execute the `AccountInformationV3` main method
   - [ ] The request must be sent
   - [ ] The response value must be printed on the terminal

## Checklist
- [X] My code follows the project's coding style and guidelines.
- [X] I have added tests that prove my feature works.
- [X] I have added relevant documentation.

Thank you for considering my contribution! 😊
